### PR TITLE
Conversion to Google docs workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,23 +11,36 @@ ifneq "$(GITSTATUS)" ""
 	GITDIRTY = -dirty
 endif
 
-export TEXMFHOME ?= lsst-texmf/texmf
+# All LaTeX make-ry commented out: 
+
+# export TEXMFHOME ?= lsst-texmf/texmf
 
 # Add aglossary.tex as a dependancy here if you want a glossary (and remove acronyms.tex)
-$(DOCNAME).pdf: $(tex) meta.tex local.bib acronyms.tex
-	latexmk -bibtex -xelatex -f $(DOCNAME)
+# $(DOCNAME).pdf: $(tex) meta.tex local.bib acronyms.tex
+# 	latexmk -bibtex -xelatex -f $(DOCNAME)
 #	makeglossaries $(DOCNAME)
 #	xelatex $(DOCNAME)
 # For glossary uncomment the 2 lines above
 
 
 # Acronym tool allows for selection of acronyms based on tags - you may want more than DM
-acronyms.tex: $(tex) myacronyms.txt
-	$(TEXMFHOME)/../bin/generateAcronyms.py -t "DM" $(tex)
+# acronyms.tex: $(tex) myacronyms.txt
+# 	$(TEXMFHOME)/../bin/generateAcronyms.py -t "DM" $(tex)
 
 # If you want a glossary you must manually run generateAcronyms.py  -gu to put the \gls in your files.
-aglossary.tex :$(tex) myacronyms.txt
-	generateAcronyms.py  -g $(tex)
+# aglossary.tex :$(tex) myacronyms.txt
+# 	generateAcronyms.py  -g $(tex)
+
+
+# Do the Google docs download. Note that we still need to make the meta.tex file, for LSSTthedocs to use.
+# We also want to check in plain text and html, for back-up - so we get this first (below), then grab the PDF:
+
+GOOGURL = https://docs.google.com/document/d/1FrwxO9Z0XS46gvEPq1E0Md9i8_e8Gxha2RD1djquGXY
+
+$(DOCNAME).pdf: meta.tex backup
+	apt-get update
+	apt-get -y install curl
+	curl -L "$(GOOGURL)/export?format=pdf" -o $@
 
 
 .PHONY: clean
@@ -46,3 +59,19 @@ meta.tex: Makefile .FORCE
 	printf '\\newcommand{\\lsstDocNum}{$(DOCNUMBER)}\n' >>$@
 	printf '\\newcommand{\\vcsRevision}{$(GITVERSION)$(GITDIRTY)}\n' >>$@
 	printf '\\newcommand{\\vcsDate}{$(GITDATE)}\n' >>$@
+
+# Here's where we download, as back-up in case the Google doc gets lost in future, copies of the Gdoc content in both plain text and html formats, and check them in to the repo.
+# Note that GitHub wants to know who is making the commit. See the discussion at https://github.community/t/how-does-one-commit-from-an-action/16127/9
+
+backup:
+	apt-get update
+	apt-get -y install curl
+	curl -L "$(GOOGURL)/export?format=txt" -o $(DOCNAME).txt
+	curl -L "$(GOOGURL)/export?format=html" | sed s%"<"%"\n<"%g > $(DOCNAME).html
+	if  [ $(GITBRANCH) = "branch" ]; then\
+		git config --local user.email github-actions@github.com;\
+		git config --local user.name github-actions;\
+		git add $(DOCNAME).txt $(DOCNAME).html;\
+		git commit -am 'Back-up txt and html downloaded on $(GITDATE) for Revision $(GITVERSION)$(GITDIRTY)';\
+		git push;\
+	fi

--- a/README.rst
+++ b/README.rst
@@ -16,10 +16,10 @@ Status
 ======
 This technote is currently in its "beta" state, accepting feedback from some "beta tester" current Rubin hiring managers, and also the members of the 2024 Joint Operations Review (JOR2024) panel.
 
-Version: 0.2
-Date: 2024-04-05
-Comment: Distributed for beta testing and JOR review 
-Owner: Bob Blum
+- Version: 0.2
+- Date: 2024-04-05
+- Comment: Distributed for beta testing and JOR review  
+- Owner: Bob Blum
 
 
 Links

--- a/README.rst
+++ b/README.rst
@@ -3,61 +3,33 @@
 .. image:: https://github.com/lsst/rtn-070/workflows/CI/badge.svg
    :target: https://github.com/lsst/rtn-070/actions/
 
-#############
-Hiring Recipe
-#############
+##############
+Hiring Recipes
+##############
 
 RTN-070
 =======
 
 Quick reference guide for Rubin Hiring Managers, with how-to's for each step of the recruitment process that bring in best practices in inclusive hiring. 
 
+Status
+------
+This technote is currently in its "beta" state, ready for feedback from the beta tester hiring managers and the members of the JO2024 panel.
+
 Links
 =====
 
-- Live drafts: https://rtn-070.lsst.io
-- GitHub: https://github.com/lsst/rtn-070
+- Live, commentable source: `RTN-070 Google doc <https://docs.google.com/document/d/1FrwxO9Z0XS46gvEPq1E0Md9i8_e8Gxha2RD1djquGXY/edit>`_
+- Publication URL: https://rtn-070.lsst.io
 
-Build
-=====
+- GitHub repository: https://github.com/lsst/rtn-070
+- Build system: https://github.com/lsst/rtn-070/actions/
 
-This repository includes lsst-texmf_ as a Git submodule.
-Clone this repository::
 
-    git clone --recurse-submodules https://github.com/lsst/rtn-070
+Editing this technical note
+===========================
 
-Compile the PDF::
-
-    make
-
-Clean built files::
-
-    make clean
-
-Updating acronyms
------------------
-
-A table of the technote's acronyms and their definitions are maintained in the ``acronyms.tex`` file, which is committed as part of this repository.
-To update the acronyms table in ``acronyms.tex``::
-
-    make acronyms.tex
-
-*Note: this command requires that this repository was cloned as a submodule.*
-
-The acronyms discovery code scans the LaTeX source for probable acronyms.
-You can ensure that certain strings aren't treated as acronyms by adding them to the `skipacronyms.txt <./skipacronyms.txt>`_ file.
-
-The lsst-texmf_ repository centrally maintains definitions for LSST acronyms.
-You can also add new acronym definitions, or override the definitions of acronyms, by editing the `myacronyms.txt <./myacronyms.txt>`_ file.
-
-Updating lsst-texmf
--------------------
-
-`lsst-texmf`_ includes BibTeX files, the ``lsstdoc`` class file, and acronym definitions, among other essential tooling for LSST's LaTeX documentation projects.
-To update to a newer version of `lsst-texmf`_, you can update the submodule in this repository::
-
-   git submodule update --init --recursive
-
-Commit, then push, the updated submodule.
-
-.. _lsst-texmf: https://github.com/lsst/lsst-texmf
+You can make modifications in "suggesting mode" to the Google doc linked above.
+Then, you should update the status line in the README and submit a pull request.
+When your suggestions have been accepted, merge the PR. 
+The published technote at https://rtn-070.lsst.io will be automatically rebuilt when your pull request is merged into the ``main`` branch on `GitHub <https://github.com/lsst/rtn-070>`_.

--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,14 @@ RTN-070
 Quick reference guide for Rubin Hiring Managers, with how-to's for each step of the recruitment process that bring in best practices in inclusive hiring. 
 
 Status
-------
-This technote is currently in its "beta" state, ready for feedback from the beta tester hiring managers and the members of the JO2024 panel.
+======
+This technote is currently in its "beta" state, accepting feedback from some "beta tester" current Rubin hiring managers, and also the members of the 2024 Joint Operations Review (JOR2024) panel.
+
+Version: 0.2
+Date: 2024-04-05
+Comment: Distributed for beta testing and JOR review 
+Owner: Bob Blum
+
 
 Links
 =====

--- a/README.rst
+++ b/README.rst
@@ -4,16 +4,14 @@
    :target: https://github.com/lsst/rtn-070/actions/
 
 ##############
-Hiring Recipes
+RTN-070 Hiring Recipes
 ##############
-
-RTN-070
-=======
 
 Quick reference guide for Rubin Hiring Managers, with how-to's for each step of the recruitment process that bring in best practices in inclusive hiring. 
 
 Status
 ======
+
 This technote is currently in its "beta" state, accepting feedback from some "beta tester" current Rubin hiring managers, and also the members of the 2024 Joint Operations Review (JOR2024) panel.
 
 - Version: 0.2
@@ -28,12 +26,10 @@ Links
 - Live, commentable source: `RTN-070 Google doc <https://docs.google.com/document/d/1FrwxO9Z0XS46gvEPq1E0Md9i8_e8Gxha2RD1djquGXY/edit>`_
 - Publication URL: https://rtn-070.lsst.io
 
-- GitHub repository: https://github.com/lsst/rtn-070
-- Build system: https://github.com/lsst/rtn-070/actions/
 
 
-Editing this technical note
-===========================
+Editing this Technote
+=====================
 
 You can make modifications in "suggesting mode" to the Google doc linked above.
 Then, you should update the status line in the README and submit a pull request.

--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,9 @@
 .. image:: https://github.com/lsst/rtn-070/workflows/CI/badge.svg
    :target: https://github.com/lsst/rtn-070/actions/
 
-##############
+######################
 RTN-070 Hiring Recipes
-##############
+######################
 
 Quick reference guide for Rubin Hiring Managers, with how-to's for each step of the recruitment process that bring in best practices in inclusive hiring. 
 


### PR DESCRIPTION
This PR will convert the document from a LaTeX format technote to one in Google docs. The README is quite different, and explains the Google docs workflow. Then, the GitHub actions are modified to download the PDF from the Google doc instead of building it from the tex source. I'll request a review from @rblum5 when it is ready (not yet!)