### PR TITLE
v0.2 title and author list

### DIFF
--- a/RTN-070.tex
+++ b/RTN-070.tex
@@ -9,13 +9,14 @@
 %\input{aglossary.tex}
 %\makeglossaries
 
-\title{Hiring Recipe}
+\title{Hiring Recipes}
 
 % Optional subtitle
 % \setDocSubtitle{A subtitle}
 
 \author{%
-Phil Marshall
+Bob Blum, Erin Coley, Rachael Fosen Cutri, Ranpal Gill, 
+Phil Marshall, Alysha Shugart, Sandrine Thomas 
 }
 
 \setDocRef{RTN-070}


### PR DESCRIPTION
Small patch to fix the appearance of https://rtn-070.lsst.io/, which seems to depend on the latex file (even though that is no longer where the doc source is).